### PR TITLE
Pass the nick_password arg through

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -18,6 +18,8 @@ mod inner {
     pub(super) struct Config {
         pub(super) nickname: String,
 
+        pub(super) nick_password: String,
+
         #[serde(default)]
         pub(super) username: String,
 
@@ -34,6 +36,8 @@ mod inner {
 #[derive(Debug)]
 pub struct Config {
     pub(crate) nickname: String,
+
+    pub(crate) nick_password: String,
 
     pub(crate) username: String,
 
@@ -106,6 +110,16 @@ impl ConfigBuilder {
         }
 
         ConfigBuilder(self.0.map(|cfg| inner::Config { nickname, ..cfg }))
+    }
+
+    pub fn nick_password<S>(self, nick_password: S) -> Self
+    where
+        S: Into<String>,
+    {
+        ConfigBuilder(self.0.map(|cfg| inner::Config {
+            nick_password: nick_password.into(),
+            ..cfg
+        }))
     }
 
     pub fn username<S>(self, username: S) -> Self
@@ -194,6 +208,8 @@ fn cook_config(mut cfg: inner::Config) -> Result<Config> {
 
     let nickname = cfg.nickname.to_owned();
 
+    let nick_password = cfg.nick_password.to_owned();
+
     let username = cfg.username.to_owned();
 
     let realname = cfg.realname.to_owned();
@@ -206,6 +222,7 @@ fn cook_config(mut cfg: inner::Config) -> Result<Config> {
             Arc::new(aatxe::Config {
                 // TODO: Allow nickname etc. to be configured per-server.
                 nickname: Some(nickname.clone()),
+                nick_password: Some(nick_password.clone()),
                 username: Some(username.clone()),
                 realname: Some(realname.clone()),
                 server: Some(server_cfg.host),
@@ -219,6 +236,7 @@ fn cook_config(mut cfg: inner::Config) -> Result<Config> {
 
     Ok(Config {
         nickname,
+        nick_password,
         username,
         realname,
         admins,


### PR DESCRIPTION
The underlying library supports the `nick_password` argument already. so this just allows the password to be passed through the `irc-bot.rs` config system.

I'm rewriting an IRC bot that's currently in go, in rust, so I expect I'll have a few more like this over time ^^

I've tested this with a minimal bot against freenode, and the bot identified successfully.