### PR TITLE
fix serdeyaml error

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,9 +5,7 @@ servers:
   - name: Mozilla
     host: irc.mozilla.org
     port: 6697
-    channels:
-      - name: '#c74d'
-      - name: '#rust-irc'
+    channels: ["#c74d","#rust-irc"]
 admins:
   - nick: c74d
     user: c74d


### PR DESCRIPTION
This potentialy fix the following error : 
```
Error(SerdeYaml(Message("invalid type: map, expected a string", Some(Pos { marker: Marker { index: 143, line: 9, col: 12 }, path: "servers[0].channels[0]" }))), State { next_error: None, backtrace: None })
```

Another way would be to update the configuration handler so the channels would accept map  instead of strings